### PR TITLE
Link libraries before fetching a contract

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -30,7 +30,6 @@ import {
   Execute
 } from "@nomiclabs/buidler/types";
 import { PartialExtension } from "./types";
-import { string } from "@nomiclabs/buidler/internal/core/params/argumentTypes";
 
 function fixProvider(providerGiven: any): any {
   // alow it to be used by ethers without any change


### PR DESCRIPTION
In the case of a contract with linked libraries, the bytecode is not updated with the libraries addresses in `fetchIfDifferent` resulting in error while creating the `ContractFactory`